### PR TITLE
Bugfix: this.member not defined

### DIFF
--- a/smartyStreets.cfc
+++ b/smartyStreets.cfc
@@ -16,6 +16,7 @@ component {
 		this.apiUrl= arguments.apiUrl;
 		this.userAgent= arguments.userAgent;
 		this.httpTimeOut= arguments.httpTimeOut;
+		this.debug= arguments.debug;
 		return this;
 	}
 


### PR DESCRIPTION
Quick fix for a minor bug with a missing `debug` member reference in the
cfc/model itself.

This fixes a bug where any time `debugLog()` gets called, it throws an error because `this.debug` was not defined.